### PR TITLE
convert object pointer to i64

### DIFF
--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -35,7 +35,7 @@ impl<'a> JValue<'a> {
     pub fn to_jni(self) -> jvalue {
         let val: jvalue = unsafe {
             match self {
-                JValue::Object(obj) => transmute(obj.into_inner()),
+                JValue::Object(obj) => transmute(obj.into_inner() as i64),
                 JValue::Byte(byte) => transmute(byte as i64),
                 JValue::Char(char) => transmute(char as u64),
                 JValue::Short(short) => transmute(short as i64),


### PR DESCRIPTION
```
cargo build --release --target=armv7-linux-androideabi
   Compiling jni-sys v0.2.1
   Compiling jni v0.2.0
error[E0512]: transmute called with differently sized types: *mut jni_sys::_jobject (32 bits) to jni_sys::jvalue (64 bits)
  --> /home/jarod/.cargo/registry/src/github.com-1ecc6299db9ec823/jni-0.2.0/src/wrapper/objects/jvalue.rs:38:40
   |
38 |                 JValue::Object(obj) => transmute(obj.into_inner()),
   |                                        ^^^^^^^^^ transmuting between 32 bits and 64 bits

error: aborting due to previous error

error: Could not compile `jni`.
```