### PR TITLE
Add JStaticMethodID and fix static method lookup.

### DIFF
--- a/src/wrapper/descriptors/method_desc.rs
+++ b/src/wrapper/descriptors/method_desc.rs
@@ -3,6 +3,7 @@ use errors::*;
 use descriptors::Desc;
 
 use objects::JMethodID;
+use objects::JStaticMethodID;
 use objects::JClass;
 
 use strings::JNIString;
@@ -16,5 +17,15 @@ impl<'a, T, U, V> Desc<'a, JMethodID<'a>> for (T, U, V)
 {
     fn lookup(self, env: &JNIEnv<'a>) -> Result<JMethodID<'a>> {
         env.get_method_id(self.0, self.1, self.2)
+    }
+}
+
+impl<'a, T, U, V> Desc<'a, JStaticMethodID<'a>> for (T, U ,V)
+    where T: Desc<'a, JClass<'a>>,
+          U: Into<JNIString>,
+          V: Into<JNIString>
+{
+    fn lookup(self, env: &JNIEnv<'a>) -> Result<JStaticMethodID<'a>> {
+        env.get_static_method_id(self.0, self.1, self.2)
     }
 }

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -1,0 +1,33 @@
+
+use std::marker::PhantomData;
+
+use sys::jmethodID;
+
+/// Wrapper around `sys::jmethodid` that adds a lifetime. This prevents it from
+/// outliving the context in which it was acquired and getting GC'd out from
+/// under us. It matches C's representation of the raw pointer, so it can be
+/// used in any of the extern function argument positions that would take a
+/// `jmethodid`. This represents static methods only since they require a
+/// different set of JNI signatures.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct JStaticMethodID<'a> {
+    internal: jmethodID,
+    lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> From<jmethodID> for JStaticMethodID<'a> {
+    fn from(other: jmethodID) -> Self {
+        JStaticMethodID {
+            internal: other,
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a> JStaticMethodID<'a> {
+    /// Unwrap to the internal jni type.
+    pub fn into_inner(self) -> jmethodID {
+        self.internal
+    }
+}

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -5,6 +5,9 @@ pub use self::jvalue::*;
 mod jmethodid;
 pub use self::jmethodid::*;
 
+mod jstaticmethodid;
+pub use self::jstaticmethodid::*;
+
 mod jfieldid;
 pub use self::jfieldid::*;
 


### PR DESCRIPTION
Hey there,

I was poking around in Android and using this library when I noticed that static methods weren't working quite right.

I took the liberty of adding JStaticMethodID which uses GetStaticMethodID since static methods aren't interchangeable and it seemed to work well with the Desc trait.

Let me know if this looks good or if you'd like any modifications, I also tried to clean up a couple warnings and some doctext that wasn't accurate.

-Val