### PR TITLE
compiling on android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ homepage = "https://docs.rs/jni"
 
 [dependencies]
 log = "0.3"
-error-chain = "0.5"
 combine = "2"
 cesu8 = "1"
 jni-sys = "0.2"
+error-chain = { version = "0.9", default-features = false }
+
+[features]
+default = ["backtrace"]
+backtrace = ["error-chain/backtrace"]


### PR DESCRIPTION
I had issues with compiling jni for android.

```
cargo build --target aarch64-linux-android
```

was failing with 

```
--- stderr
configure: WARNING: If you wanted to set the --build type, don't use --host.
    If a cross compiler is detected then cross compile mode will be used.
configure: error: in `/Users/marek/projects/ethcore/jni-rs/target/aarch64-linux-android/debug/build/backtrace-sys-e4956d294e94bde6/out':
configure: error: C compiler cannot create executables
```

-----

This pr is workaround for this issue. It allows compiling jni without `backtrace` library