### PR TITLE
add class cache to support android multithreading

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![feature(drop_types_in_const)]
 
 //! # Safe JNI Bindings in Rust
 //!
@@ -189,6 +190,9 @@ mod wrapper {
     /// Actual communication with the JVM
     mod jnienv;
     pub use self::jnienv::*;
+
+    mod javavm;
+    pub use self::javavm::*;
 }
 
 pub use wrapper::*;

--- a/src/wrapper/javavm.rs
+++ b/src/wrapper/javavm.rs
@@ -1,0 +1,72 @@
+use std::str;
+
+use std::marker::PhantomData;
+
+use errors::*;
+
+use sys::{self, JavaVMAttachArgs};
+use std::os::raw::c_void;
+use std::ptr::null_mut;
+
+
+use wrapper::JNIEnv;
+
+/// JavaVM
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct JavaVM<'a> {
+    internal: *mut sys::JavaVM,
+    lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> From<*mut sys::JavaVM> for JavaVM<'a> {
+    fn from(other: *mut sys::JavaVM) -> Self {
+        JavaVM {
+            internal: other,
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a> JavaVM<'a> {
+    /// get JNIEnv from JavaVM
+    pub fn get_env(&self) -> Result<JNIEnv> {
+        let mut ptr: *mut c_void = null_mut();
+        let pptr = &mut ptr as *mut *mut c_void;
+        unsafe {
+            let status = jni_unchecked!(self.internal,
+                                        GetEnv,
+                                        pptr,
+                                        sys::JNI_VERSION_1_6);
+            if status != sys::JNI_OK {
+                return Err(ErrorKind::JavaException.into());
+            }
+        }
+        Ok(JNIEnv::from(ptr as *mut sys::JNIEnv))
+    }
+
+    /// call AttachCurrentThread to get JNIEnv
+    pub fn attach_current_thread(&self) -> Result<JNIEnv<'static>> {
+        let mut ptr: *mut c_void = null_mut();
+        let pptr = &mut ptr as *mut *mut c_void;
+        use std::ffi::CString;
+        let mut args = JavaVMAttachArgs {
+            version: sys::JNI_VERSION_1_6,
+            group: null_mut(),
+            name: CString::new("default").unwrap().into_raw(),
+        };
+        let args_ptr = &mut args;
+
+        unsafe {
+            let status = jni_unchecked!(self.internal,
+                                        AttachCurrentThread,
+                                        pptr,
+                                        args_ptr as *mut JavaVMAttachArgs as
+                                        *mut c_void);
+            if status != sys::JNI_OK {
+                return Err(ErrorKind::JavaException.into());
+            }
+        }
+        Ok(JNIEnv::from(ptr as *mut sys::JNIEnv))
+    }
+}

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::iter::IntoIterator;
 
 use std::slice;
-
+use std::collections::HashMap;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 
@@ -13,6 +13,9 @@ use errors::*;
 
 use sys::{self, jvalue, jint, jlong, jsize, jbyte, jboolean, jbyteArray};
 use std::os::raw::{c_char, c_void};
+use std::ptr::null_mut;
+
+use wrapper::JavaVM;
 
 use strings::JNIString;
 use strings::JavaStr;
@@ -52,6 +55,7 @@ use signature::Primitive;
 /// applicable, the null error is changed to a more applicable error type, such
 /// as `MethodNotFound`.
 #[repr(C)]
+#[derive(Debug, Clone)]
 pub struct JNIEnv<'a> {
     internal: *mut sys::JNIEnv,
     lifetime: PhantomData<&'a ()>,
@@ -65,6 +69,65 @@ impl<'a> From<*mut sys::JNIEnv> for JNIEnv<'a> {
         }
     }
 }
+
+/// cache class for jni multithreading support of android ([see
+/// android doc](https://developer.android.com/training/articles/perf-jni.html#faq_FindClass))
+///
+/// Example
+/// cache your jvm and needed classes in the thread before new thread is created:
+/// ```rust,ignore
+/// let jvm = env.cache_java_vm().unwrap();
+/// let _ = env.find_class(CLASS_NAME);
+/// ```
+///
+/// use `JniCache::get_jvm()` to get cached jvm afterwards
+/// `find_class` calls afterwards will use the cached class
+pub struct JniCache {
+    /// class map
+    class_map: Option<HashMap<String, JClass<'static>>>,
+    /// jvm
+    pub jvm: Option<JavaVM<'static>>,
+}
+
+impl JniCache {
+    /// cache a class
+    pub fn cache_class(&mut self, name: String, java_class: JClass<'static>) {
+        if let Some(ref mut class_map) = self.class_map {
+            class_map.insert(name, java_class);
+            debug!("JNI_CACHE cache_class class_map: {:?}, java_class: {:?}", class_map, java_class);
+        } else {
+            self.class_map = Some(HashMap::new());
+        }
+
+    }
+
+    /// get class from cache
+    pub fn get_class(&mut self, name: String) -> Option<&JClass<'static>> {
+        if let Some(ref class_map) = self.class_map {
+            debug!("JNI_CACHE get_class name: {:?}", name);
+            class_map.get(&name)
+        } else {
+            self.class_map = Some(HashMap::new());
+            None
+        }
+    }
+
+    /// get jvm from cache
+    pub fn get_jvm() -> Option<JavaVM<'static>> {
+        unsafe {
+            debug!("JNI_CACHE get_jvm: {:?}", JNI_CACHE.jvm);
+            JNI_CACHE.jvm
+        }
+    }
+
+    /// cache jvm
+    pub fn cache_jvm(&mut self, jvm: JavaVM<'static>) {
+        debug!("JNI_CACHE cache_jvm jvm: {:?}", jvm);
+        self.jvm = Some(jvm);
+    }
+}
+
+static mut JNI_CACHE: JniCache = JniCache {class_map: None, jvm: None};
 
 impl<'a> JNIEnv<'a> {
     /// Get the java version that we're being executed from. This is encoded and
@@ -101,7 +164,22 @@ impl<'a> JNIEnv<'a> {
         where S: Into<JNIString>
     {
         let name = name.into();
-        let class = jni_call!(self.internal, FindClass, name.as_ptr());
+        unsafe {
+            let java_class = JNI_CACHE.get_class(String::from(name.clone()));
+            debug!("find_class got cached class: {:?}", java_class);
+            if let Some(java_class) = java_class {
+                return Ok(*java_class)
+            } else {
+                error!("find_class failed name:{:?}", String::from(name.clone()));
+            }
+        }
+
+        let class: JClass<'static> = jni_call!(self.internal, FindClass, name.as_ptr());
+        let new_ref: JClass<'static> = jni_call!(self.internal, NewGlobalRef, class.into_inner());
+
+        unsafe {
+            JNI_CACHE.cache_class(String::from(name.clone()), new_ref);
+        }
         Ok(class)
     }
 
@@ -1006,6 +1084,29 @@ impl<'a> JNIEnv<'a> {
                life: Default::default(),
            })
     }
+
+    /// get JavaVM and cache it
+    pub fn cache_java_vm(&self) -> Result<JavaVM> {
+        let jvm = JniCache::get_jvm();
+        if let Some(jvm) = jvm {
+            return Ok(jvm);
+        }
+
+        let mut ptr: *mut sys::JavaVM = null_mut();
+        let pptr = &mut ptr as *mut *mut sys::JavaVM;
+        unsafe {
+            let status = jni_unchecked!(self.internal, GetJavaVM, pptr);
+            if status != sys::JNI_OK {
+                return Err(ErrorKind::JavaException.into());
+            }
+        }
+
+        let jvm = JavaVM::from(ptr as *mut sys::JavaVM);
+        unsafe {
+            JNI_CACHE.cache_jvm(jvm);
+        }
+        Ok(jvm)
+    }
 }
 
 /// Guard for a lock on a java object. This gets returned from the `lock_obj`
@@ -1029,4 +1130,3 @@ impl<'a> Drop for MonitorGuard<'a> {
         }
     }
 }
-

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -5,7 +5,7 @@ use sys::{jobject, jclass};
 /// Lifetime'd representation of a `jclass`. Just a `JObject` wrapped in a new
 /// class.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct JClass<'a>(JObject<'a>);
 
 impl<'a> From<jclass> for JClass<'a> {

--- a/src/wrapper/strings/ffi_str.rs
+++ b/src/wrapper/strings/ffi_str.rs
@@ -10,6 +10,7 @@ use cesu8::to_java_cesu8;
 /// Wrapper for `std::ffi::CString` that also takes care of encoding between
 /// UTF-8 and Java's Modified UTF-8. As with `CString`, this implements `Deref`
 /// to `&JNIStr`.
+#[derive(Clone)]
 pub struct JNIString {
     internal: ffi::CString,
 }


### PR DESCRIPTION

cache class for jni multithreading support of android ([see
android doc](https://developer.android.com/training/articles/perf-jni.html#faq_FindClass))

Example
cache your jvm and needed classes in the thread before new thread is created:
```rust,ignore
let jvm = env.cache_java_vm().unwrap();
let _ = env.find_class(CLASS_NAME);
```

use `JniCache::get_jvm()` to get cached jvm afterwards
`find_class` calls afterwards will use the cached class