### PR TITLE
Add function for 'jbyteArray' to 'Vec<u8>' conversion

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -758,6 +758,17 @@ impl<'a> JNIEnv<'a> {
         Ok(bytes)
     }
 
+    /// Converts a java byte array to a rust vector of bytes.
+    pub fn convert_byte_array(&self, array: jbyteArray) -> Result<Vec<u8>> {
+        let length = jni_non_null_call!(self.internal, GetArrayLength, array);
+        let mut vec = vec![0u8; length as usize];
+        unsafe {
+            jni_unchecked!(self.internal, GetByteArrayRegion, array, 0, length,
+                vec.as_mut_ptr() as *mut i8);
+        }
+        Ok(vec)
+    }
+
     /// Get a field without checking the provided type against the actual field.
     #[allow(unused_unsafe)]
     pub unsafe fn get_field_unsafe<T>(&self, obj: JObject, field: T, ty: JavaType) -> Result<JValue>

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -60,7 +60,7 @@ macro_rules! jni_unchecked {
     })
 }
 
-macro_rules! jni_call {
+macro_rules! jni_non_null_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         trace!("calling checked jni method: {}", stringify!($name));
         #[allow(unused_unsafe)]
@@ -69,8 +69,15 @@ macro_rules! jni_call {
             let res = jni_method!($jnienv, $name)($jnienv, $($args),*);
             check_exception!($jnienv);
             trace!("exiting unsafe");
-            non_null!(res, concat!(stringify!($name), " result")).into()
+            res
         }
+    })
+}
+
+macro_rules! jni_call {
+    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
+        let res = jni_non_null_call!($jnienv, $name $(, $args)*);
+        non_null!(res, concat!(stringify!($name), " result")).into()
     })
 }
 


### PR DESCRIPTION
Hi,

I need a way to convert `jbyteArray` to `Vec<u8>`, so I have made a pretty straightforward implementation. Probably it would be better to export all array related JNI functions, but I don't see a clear way to improve their ergonomic. Other and even more flexible (but less convenient) solution is to make access for the underlying `sys::JNIEnv` interface, so custom workaround can be made if `jni-rs` public api lacks something.