### PR TITLE
Add 'Clone' and 'Copy' imlementations for the 'JNIEnv'

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -52,6 +52,7 @@ use signature::Primitive;
 /// applicable, the null error is changed to a more applicable error type, such
 /// as `MethodNotFound`.
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct JNIEnv<'a> {
     internal: *mut sys::JNIEnv,
     lifetime: PhantomData<&'a ()>,


### PR DESCRIPTION
`JNIEnv` is passed by value to the extern functions, so Clippy warns about "needless pass by value".
I suppose there is no harm in adding `Copy`?