### PR TITLE
Uncomment 'jvalue' trace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://docs.rs/jni"
 log = "0.3"
 combine = "2"
 cesu8 = "1"
-jni-sys = "0.2.4"
+jni-sys = "0.2.5"
 error-chain = { version = "0.10", default-features = false }
 
 [features]

--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -51,8 +51,7 @@ impl<'a> JValue<'a> {
 
             value
         };
-        // TODO(jechas01): re-add this once jni-sys adds it back
-        // trace!("converted {:?} to jvalue {:?}", self, val._data);
+        trace!("converted {:?} to jvalue {:?}", self, val._data);
         val
     }
 


### PR DESCRIPTION
jni-sys fix [has been merged](https://github.com/sfackler/rust-jni-sys/pull/6), so `trace!` can be uncommented now.