### PR TITLE
Update example and documentation to use extern "system"

### DIFF
--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -17,14 +17,14 @@ use jni::sys::jstring;
 #[no_mangle]
 // This turns off linter warnings because the name doesn't conform to conventions.
 #[allow(non_snake_case)]
-pub extern "C" fn Java_HelloWorld_hello(env: JNIEnv,
-                                        // this is the class that owns our
-                                        // static method. Not going to be used,
-                                        // but still needs to have an argument
-                                        // slot
-                                        class: JClass,
-                                        input: JString)
-                                        -> jstring {
+pub extern "system" fn Java_HelloWorld_hello(env: JNIEnv,
+                                             // this is the class that owns our
+                                             // static method. Not going to be used,
+                                             // but still needs to have an argument
+                                             // slot
+                                             class: JClass,
+                                             input: JString)
+                                             -> jstring {
     // First, we have to get the string out of java. Check out the `strings`
     // module for more info on how this works.
     let input: String =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,14 +116,14 @@
 //! // This turns off linter warnings because the name doesn't conform to
 //! // conventions.
 //! #[allow(non_snake_case)]
-//! pub extern "C" fn Java_HelloWorld_hello(env: JNIEnv,
-//!                                         // this is the class that owns our
-//!                                         // static method. Not going to be
-//!                                         // used, but still needs to have an
-//!                                         // argument slot
-//!                                         class: JClass,
-//!                                         input: JString)
-//!                                         -> jstring {
+//! pub extern "system" fn Java_HelloWorld_hello(env: JNIEnv,
+//!                                              // this is the class that owns our
+//!                                              // static method. Not going to be
+//!                                              // used, but still needs to have an
+//!                                              // argument slot
+//!                                              class: JClass,
+//!                                              input: JString)
+//!                                              -> jstring {
 //!     // First, we have to get the string out of java. Check out the `strings`
 //!     // module for more info on how this works.
 //!     let input: String =


### PR DESCRIPTION
`JNICALL` on Windows 32 bits is defined as `__stdcall`. Using `extern "system"` make the Rust compiler use `__stdcall` for that platform and `C`for others.

I had crashes when `jni-sys` was using the wrong calling convention sfackler/rust-jni-sys#4, but not from the Java JNI method function signatures,  but from `JNIEnv`. There should be situations when the wrong calling convention on this side can crash the JVM too.