### PR TITLE
Allowing the use of GlobalRef as an JObject and new callback examples

### DIFF
--- a/example/HelloWorld.h
+++ b/example/HelloWorld.h
@@ -15,6 +15,38 @@ extern "C" {
 JNIEXPORT jstring JNICALL Java_HelloWorld_hello
   (JNIEnv *, jclass, jstring);
 
+/*
+ * Class:     HelloWorld
+ * Method:    factAndCallMeBack
+ * Signature: (ILHelloWorld;)V
+ */
+JNIEXPORT void JNICALL Java_HelloWorld_factAndCallMeBack
+  (JNIEnv *, jclass, jint, jobject);
+
+/*
+ * Class:     HelloWorld
+ * Method:    counterNew
+ * Signature: (LHelloWorld;)J
+ */
+JNIEXPORT jlong JNICALL Java_HelloWorld_counterNew
+  (JNIEnv *, jclass, jobject);
+
+/*
+ * Class:     HelloWorld
+ * Method:    counterIncrement
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_HelloWorld_counterIncrement
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     HelloWorld
+ * Method:    counterDestroy
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_HelloWorld_counterDestroy
+  (JNIEnv *, jclass, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/example/HelloWorld.java
+++ b/example/HelloWorld.java
@@ -1,5 +1,10 @@
 class HelloWorld {
     private static native String hello(String input);
+    private static native void factAndCallMeBack(int n, HelloWorld callback);
+
+    private static native long counterNew(HelloWorld callback);
+    private static native void counterIncrement(long counter_ptr);
+    private static native void counterDestroy(long counter_ptr);
 
     static {
         System.loadLibrary("mylib");
@@ -8,5 +13,23 @@ class HelloWorld {
     public static void main(String[] args) {
         String output = HelloWorld.hello("josh");
         System.out.println(output);
+
+        HelloWorld.factAndCallMeBack(6, new HelloWorld());
+
+        long counter_ptr = counterNew(new HelloWorld());
+
+        for (int i = 0; i < 5; i++) {
+          counterIncrement(counter_ptr);
+        }
+
+        counterDestroy(counter_ptr);
+    }
+
+    public void factCallback(int res) {
+      System.out.println("factCallback: res = " + res);
+    }
+
+    public void counterCallback(int count) {
+      System.out.println("counterCallback: count = " + count);
     }
 }

--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -1,27 +1,29 @@
 extern crate jni;
 
-// This is the interface to the JVM that we'll call the majority of our methods on.
+// This is the interface to the JVM that we'll
+// call the majority of our methods on.
 use jni::JNIEnv;
 
 // These objects are what you should use as arguments to your native function.
 // They carry extra lifetime information to prevent them escaping this context
 // and getting used after being GC'd.
-use jni::objects::{JClass, JString};
+use jni::objects::{JClass, JString, JObject, GlobalRef};
 
 // This is just a pointer. We'll be returning it from our function.
 // We can't return one of the objects with lifetime information because the
 // lifetime checker won't let us.
-use jni::sys::jstring;
+use jni::sys::{jint, jlong, jstring};
 
 // This keeps rust from "mangling" the name and making it unique for this crate.
 #[no_mangle]
-// This turns off linter warnings because the name doesn't conform to conventions.
+// This turns off linter warnings because
+// the name doesn't conform to conventions.
 #[allow(non_snake_case)]
 pub extern "system" fn Java_HelloWorld_hello(env: JNIEnv,
                                              // this is the class that owns our
-                                             // static method. Not going to be used,
-                                             // but still needs to have an argument
-                                             // slot
+                                             // static method. Not going to be
+                                             // used, but still needs to have
+                                             // an argument slot
                                              class: JClass,
                                              input: JString)
                                              -> jstring {
@@ -37,6 +39,76 @@ pub extern "system" fn Java_HelloWorld_hello(env: JNIEnv,
 
     // Finally, extract the raw pointer to return.
     output.into_inner()
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_HelloWorld_factAndCallMeBack(env: JNIEnv,
+                                                         _class: JClass,
+                                                         n: jint,
+                                                         callback: JObject) {
+    let i = n as i32;
+    let res: jint = (2..i + 1).product();
+
+    env.call_method(callback, "factCallback", "(I)V", &[res.into()]).unwrap();
+}
+
+struct Counter {
+    count: i32,
+    callback: GlobalRef,
+}
+
+impl Counter {
+    pub fn new(callback: GlobalRef) -> Counter {
+        Counter {
+            count: 0,
+            callback: callback,
+        }
+    }
+
+    pub fn increment(&mut self, env: JNIEnv) {
+        self.count = self.count + 1;
+        env.call_method(*self.callback.as_ref(),
+                         "counterCallback",
+                         "(I)V",
+                         &[self.count.into()])
+            .unwrap();
+    }
+}
+
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "system" fn Java_HelloWorld_counterNew(env: JNIEnv,
+                                                         _class: JClass,
+                                                         callback: JObject)
+                                                         -> jlong {
+    let global_ref = env.new_global_ref(callback).unwrap();
+    let counter = Counter::new(global_ref);
+
+    Box::into_raw(Box::new(counter)) as jlong
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "system" fn Java_HelloWorld_counterIncrement(
+    env: JNIEnv,
+    _class: JClass,
+    counter_ptr: jlong
+){
+    let counter = &mut *(counter_ptr as *mut Counter);
+
+    counter.increment(env);
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub unsafe extern "system" fn Java_HelloWorld_counterDestroy(
+    _env: JNIEnv,
+    _class: JClass,
+    counter_ptr: jlong
+){
+    let _boxed_counter = Box::from_raw(counter_ptr as *mut Counter);
 }
 
 #[cfg(test)]

--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -68,7 +68,7 @@ impl Counter {
 
     pub fn increment(&mut self, env: JNIEnv) {
         self.count = self.count + 1;
-        env.call_method(*self.callback.as_ref(),
+        env.call_method((&self.callback).into(),
                          "counterCallback",
                          "(I)V",
                          &[self.count.into()])

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -1,6 +1,8 @@
-use std::convert::From;
+use std::convert::{AsRef, From};
 
 use errors::*;
+
+use objects::JObject;
 
 use sys::{jobject, JNIEnv};
 
@@ -13,11 +15,26 @@ pub struct GlobalRef {
     env: *mut JNIEnv,
 }
 
+impl<'a> AsRef<JObject<'a>> for GlobalRef {
+    fn as_ref(&self) -> &JObject<'a> {
+        unsafe { ::std::mem::transmute(&self.obj) }
+    }
+}
+
+impl<'a> From<GlobalRef> for JObject<'a> {
+    fn from(other: GlobalRef) -> JObject<'a> {
+        other.obj.into()
+    }
+}
+
 impl GlobalRef {
     /// Create a new global reference object. This assumes that
     /// `CreateGlobalRef` has already been called.
     pub unsafe fn new(env: *mut JNIEnv, obj: jobject) -> Self {
-        GlobalRef { obj: obj, env: env }
+        GlobalRef {
+            obj: obj,
+            env: env,
+        }
     }
 
     fn drop_ref(&mut self) -> Result<()> {

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -15,14 +15,8 @@ pub struct GlobalRef {
     env: *mut JNIEnv,
 }
 
-impl<'a> AsRef<JObject<'a>> for GlobalRef {
-    fn as_ref(&self) -> &JObject<'a> {
-        &self.obj
-    }
-}
-
-impl<'a> From<GlobalRef> for JObject<'a> {
-    fn from(other: GlobalRef) -> JObject<'a> {
+impl<'a> From<&'a GlobalRef> for JObject<'a> {
+    fn from(other: &'a GlobalRef) -> JObject<'a> {
         other.obj
     }
 }

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -1,4 +1,4 @@
-use std::convert::{AsRef, From};
+use std::convert::From;
 
 use errors::*;
 


### PR DESCRIPTION
These modifications solve #25.

It allows to turn a `GlobalRef` into an `JObject` by implementing both `AsRef` and `From`
```rust
let obj = *self.global_ref.as_ref();
```

The internal `jobject` of `GlobalRef` is replaced by an `JObject<'static>`. For other approach without that change(uses unsafe `mem::transmute`) see https://github.com/angel-manuel/jni-rs/commit/fb6a3de633709829f22fc133632a5f188614cf58

While testing, I added callbacks, both using JObject and GlobalRef, to the example. Maybe is too much for a HelloWorld example, drop it or do what you see fit.