### PR TITLE
Add `Desc<JClass>` for the `GlobalRef`

### DIFF
--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -23,6 +23,7 @@ impl<'a, 'b> Desc<'a, JClass<'a>> for JObject<'b> {
     }
 }
 
+/// This conversion assumes that the `GlobalRef` is a pointer to a class object.
 impl<'a> Desc<'a, JClass<'a>> for &'a GlobalRef {
     fn lookup(self, _: &JNIEnv<'a>) -> Result<JClass<'a>> {
         Ok(self.as_obj().into())

--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -1,6 +1,6 @@
 use strings::JNIString;
 
-use objects::{JObject, JClass};
+use objects::{JObject, JClass, GlobalRef};
 
 use descriptors::Desc;
 
@@ -20,5 +20,11 @@ where
 impl<'a, 'b> Desc<'a, JClass<'a>> for JObject<'b> {
     fn lookup(self, env: &JNIEnv<'a>) -> Result<JClass<'a>> {
         env.get_object_class(self)
+    }
+}
+
+impl<'a> Desc<'a, JClass<'a>> for &'a GlobalRef {
+    fn lookup(self, _: &JNIEnv<'a>) -> Result<JClass<'a>> {
+        Ok(self.as_obj().into())
     }
 }

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -28,7 +28,7 @@ impl<'a> From<JClass<'a>> for JObject<'a> {
     }
 }
 
-/// This conversion assumes that the `JClass` is a pointer to a class object.
+/// This conversion assumes that the `JObject` is a pointer to a class object.
 impl<'a> From<JObject<'a>> for JClass<'a> {
     fn from(other: JObject) -> JClass {
         (other.into_inner() as jclass).into()

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -28,6 +28,7 @@ impl<'a> From<JClass<'a>> for JObject<'a> {
     }
 }
 
+/// This conversion assumes that the `JClass` is a pointer to a class object.
 impl<'a> From<JObject<'a>> for JClass<'a> {
     fn from(other: JObject) -> JClass {
         (other.into_inner() as jclass).into()


### PR DESCRIPTION
This allows to use `GlobalRef` with `JNIEnv`'s `new_object` method.

The use-case is the following: object class is obtained by the `find_class` function, then global reference (obtained by `new_global_ref` call) of that class is stored for the later use. If this object's constructor should be called, then it is required to use the `new_object` function, which cannot take `GlobalRef` as parameter.