### PR TITLE
Call delete_local_ref for classes objects

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -770,9 +770,12 @@ impl<'a> JNIEnv<'a> {
 
         let class = self.get_object_class(obj)?;
 
-        unsafe {
+        let res = unsafe {
             self.call_method_unsafe(obj, (class, name, sig), parsed.ret, args)
-        }
+        };
+        self.delete_local_ref(JObject::from(class))?;
+
+        res
     }
 
     /// Calls a static method safely. This comes with a number of
@@ -1574,6 +1577,8 @@ impl<'a> JNIEnv<'a> {
 
         let field_id: JFieldID = (class, name, ty).lookup(self)?;
 
+        self.delete_local_ref(JObject::from(class))?;
+
         unsafe { self.get_field_unsafe(obj, field_id, parsed) }
     }
 
@@ -1633,7 +1638,11 @@ impl<'a> JNIEnv<'a> {
 
         let class = self.get_object_class(obj)?;
 
-        unsafe { self.set_field_unsafe(obj, (class, name, ty), val) }
+        let res = unsafe { self.set_field_unsafe(obj, (class, name, ty), val) };
+
+        self.delete_local_ref(JObject::from(class))?;
+
+        res
     }
 
     /// Surrenders ownership of a rust object to Java. Requires an object with a
@@ -1659,6 +1668,7 @@ impl<'a> JNIEnv<'a> {
     {
         let class = self.get_object_class(obj)?;
         let field_id: JFieldID = (class, &field, "J").lookup(self)?;
+        self.delete_local_ref(JObject::from(class))?;
 
         let guard = self.lock_obj(obj)?;
 
@@ -1719,6 +1729,7 @@ impl<'a> JNIEnv<'a> {
     {
         let class = self.get_object_class(obj)?;
         let field_id: JFieldID = (class, &field, "J").lookup(self)?;
+        self.delete_local_ref(JObject::from(class))?;
 
         let mbox = {
             let guard = self.lock_obj(obj)?;


### PR DESCRIPTION
Fixes a "local reference table overflow (max=512)" error experienced with Android <= 7 and performance slow-down with Android 8.

Such error can occur by using `env.get_field()` in loops when going through elements of a jobjectArray.

I also made an Android app to reproduce the bug and test the fix easily, [available on this repo](https://github.com/supercurio/android-rust-jni-tests)

It's possible that this accumulation of local references still occur with the [`env.get_object_class` call in class_desc.rs](https://github.com/prevoty/jni-rs/blob/v0.5.2/src/wrapper/descriptors/class_desc.rs#L22), but I don't know how to fix this one.

Would it be possible to implement automatic calls to delete_local_ref on the Drop trait for everything concerned? I suppose it would mean to keep a JNIEnv around for each.
Since Android limits the local reference count strictly, it could ease the development with this crate a lot and make its behavior in apps in the wild more predictable.