### PR TITLE
Add Invocation API and multi-threading support

### DIFF
--- a/example/HelloWorld.h
+++ b/example/HelloWorld.h
@@ -47,6 +47,14 @@ JNIEXPORT void JNICALL Java_HelloWorld_counterIncrement
 JNIEXPORT void JNICALL Java_HelloWorld_counterDestroy
   (JNIEnv *, jclass, jlong);
 
+/*
+ * Class:     HelloWorld
+ * Method:    asyncComputation
+ * Signature: (LHelloWorld;)V
+ */
+JNIEXPORT void JNICALL Java_HelloWorld_asyncComputation
+  (JNIEnv *, jclass, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/example/HelloWorld.java
+++ b/example/HelloWorld.java
@@ -6,6 +6,8 @@ class HelloWorld {
     private static native void counterIncrement(long counter_ptr);
     private static native void counterDestroy(long counter_ptr);
 
+    private static native void asyncComputation(HelloWorld callback);
+
     static {
         System.loadLibrary("mylib");
     }
@@ -23,6 +25,9 @@ class HelloWorld {
         }
 
         counterDestroy(counter_ptr);
+
+        System.out.println("Invoking asyncComputation (thread id = " + Thread.currentThread().getId() + ")");
+        asyncComputation(new HelloWorld());
     }
 
     public void factCallback(int res) {
@@ -31,5 +36,9 @@ class HelloWorld {
 
     public void counterCallback(int count) {
       System.out.println("counterCallback: count = " + count);
+    }
+
+    public void asyncCallback(int progress) {
+        System.out.println("asyncCallback: thread id = " + Thread.currentThread().getId() + ", progress = " + progress + "%");
     }
 }

--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -134,7 +134,7 @@ pub extern "system" fn Java_HelloWorld_asyncComputation(
     // Then we need to detach it from the `JNIEnv` it was created from, because
     // `GlobalRef` is not `Send`. We will then re-attach it to the right `JNIEnv`
     // once inside the thread.
-    let callback = callback.detach();
+    let callback = callback.detach().unwrap();
 
     // Use channel to prevent the Java program to finish before the thread
     // has chance to start.

--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -7,12 +7,16 @@ use jni::JNIEnv;
 // These objects are what you should use as arguments to your native function.
 // They carry extra lifetime information to prevent them escaping this context
 // and getting used after being GC'd.
-use jni::objects::{JClass, JString, JObject, GlobalRef};
+use jni::objects::{GlobalRef, JClass, JObject, JString};
 
 // This is just a pointer. We'll be returning it from our function.
 // We can't return one of the objects with lifetime information because the
 // lifetime checker won't let us.
 use jni::sys::{jint, jlong, jstring};
+
+use std::thread;
+use std::time::Duration;
+use std::sync::mpsc;
 
 // This keeps rust from "mangling" the name and making it unique for this crate.
 #[no_mangle]
@@ -24,7 +28,7 @@ pub extern "system" fn Java_HelloWorld_hello(env: JNIEnv,
                                              // static method. Not going to be
                                              // used, but still needs to have
                                              // an argument slot
-                                             class: JClass,
+                                             _class: JClass,
                                              input: JString)
                                              -> jstring {
     // First, we have to get the string out of java. Check out the `strings`
@@ -109,6 +113,58 @@ pub unsafe extern "system" fn Java_HelloWorld_counterDestroy(
     counter_ptr: jlong
 ){
     let _boxed_counter = Box::from_raw(counter_ptr as *mut Counter);
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_HelloWorld_asyncComputation(
+    env: JNIEnv,
+    _class: JClass,
+    callback: JObject,
+) {
+    // `JNIEnv` cannot be sent across thread boundaries. To be able to use JNI
+    // functions in other threads, we must first obtain the `JavaVM` interface
+    // which, unlike `JNIEnv` is `Send`.
+    let jvm = env.get_java_vm().unwrap();
+
+    // We need to obtain global reference to the `callback` object before sending
+    // it to the thread, to prevent it from being collected by the GC.
+    let callback = env.new_global_ref(callback).unwrap();
+
+    // Then we need to detach it from the `JNIEnv` it was created from, because
+    // `GlobalRef` is not `Send`. We will then re-attach it to the right `JNIEnv`
+    // once inside the thread.
+    let callback = callback.detach();
+
+    // Use channel to prevent the Java program to finish before the thread
+    // has chance to start.
+    let (tx, rx) = mpsc::channel();
+
+    let _ = thread::spawn(move || {
+        // Signal that the thread has started.
+        tx.send(()).unwrap();
+
+        // Use the `JavaVM` interface to attach a `JNIEnv` to the current thread.
+        let env = jvm.attach_current_thread().unwrap();
+
+        // Then attach the detached `callback` global ref to this  newly obtained
+        // `JNIEnv`, producing `GlobalRef` which we can use normally.
+        let callback = callback.attach(&*env);
+        let callback = callback.as_obj();
+
+        for i in 0..11 {
+            let progress = (i * 10) as jint;
+            // Now we can use all available `JNIEnv` functionality normally.
+            env.call_method(callback, "asyncCallback", "(I)V", &[progress.into()])
+                .unwrap();
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        // The current thread is detached automatically when `env` goes out of scope.
+    });
+
+    // Wait until the thread has started.
+    rx.recv().unwrap();
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,10 @@ mod wrapper {
     /// Actual communication with the JVM
     mod jnienv;
     pub use self::jnienv::*;
+
+    /// Java VM interface
+    mod java_vm;
+    pub use self::java_vm::*;
 }
 
 pub use wrapper::*;

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -48,6 +48,10 @@ error_chain!{
             description("mutex already locked")
             display("mutex already locked")
         }
+        Detached {
+            description("Current thread is not attached to the java VM")
+            display("Current thread is not attached to the java VM")
+        }
     }
 }
 

--- a/src/wrapper/java_vm.rs
+++ b/src/wrapper/java_vm.rs
@@ -49,6 +49,20 @@ impl JavaVM {
             JNIEnv::from_raw(ptr as *mut sys::JNIEnv)
         }
     }
+
+    /// Get the `JNIEnv` associated with the current thread, or `ErrorKind::Detached`
+    /// if the current thread is not attached to the java VM.
+    pub fn get_env(&self) -> Result<JNIEnv> {
+        let mut ptr = ptr::null_mut();
+        unsafe {
+            let res = jni_unchecked!(self.0, GetEnv, &mut ptr, sys::JNI_VERSION_1_1);
+            match res {
+                sys::JNI_OK => JNIEnv::from_raw(ptr as *mut sys::JNIEnv),
+                sys::JNI_EDETACHED => Err(Error::from(ErrorKind::Detached)),
+                _ => unreachable!(),
+            }
+        }
+    }
 }
 
 /// A RAII implementation of scoped guard which detaches the current thread

--- a/src/wrapper/java_vm.rs
+++ b/src/wrapper/java_vm.rs
@@ -1,0 +1,87 @@
+use errors::*;
+use JNIEnv;
+
+use sys;
+
+use std::ptr;
+use std::ops::Deref;
+
+/// The invocation API.
+pub struct JavaVM(*mut sys::JavaVM);
+
+unsafe impl Send for JavaVM {}
+unsafe impl Sync for JavaVM {}
+
+impl JavaVM {
+    /// Create a JavaVM from a raw pointer.
+    pub fn from_raw(ptr: *mut sys::JavaVM) -> Result<Self> {
+        non_null!(ptr, "from_raw ptr argument");
+        Ok(JavaVM(ptr))
+    }
+
+    /// Attaches the current thread to a Java VM. The resulting `AttachGuard`
+    /// can be dereferenced to a `JNIEnv` and automatically detaches the thread
+    /// when dropped.
+    pub fn attach_current_thread(&self) -> Result<AttachGuard> {
+        let mut ptr = ptr::null_mut();
+        unsafe {
+            // TODO: Handle errors
+            let _ = jni_unchecked!(self.0, AttachCurrentThread, &mut ptr, ptr::null_mut());
+            let env = JNIEnv::from_raw(ptr as *mut sys::JNIEnv)?;
+            Ok(AttachGuard {
+                java_vm: self,
+                env: env,
+            })
+        }
+    }
+
+    /// Attaches the current thread to a Java VM as a daemon.
+    pub fn attach_current_thread_as_daemon(&self) -> Result<JNIEnv> {
+        let mut ptr = ptr::null_mut();
+        unsafe {
+            // TODO: Handle errors
+            let _ = jni_unchecked!(
+                self.0,
+                AttachCurrentThreadAsDaemon,
+                &mut ptr,
+                ptr::null_mut()
+            );
+            JNIEnv::from_raw(ptr as *mut sys::JNIEnv)
+        }
+    }
+}
+
+/// A RAII implementation of scoped guard which detaches the current thread
+/// when dropped. The attached `JNIEnv` can be accessed through this guard
+/// via its `Deref` implementation.
+pub struct AttachGuard<'a> {
+    java_vm: &'a JavaVM,
+    env: JNIEnv<'a>,
+}
+
+impl<'a> AttachGuard<'a> {
+    fn detach(&mut self) -> Result<()> {
+        unsafe {
+            jni_unchecked!(self.java_vm.0, DetachCurrentThread);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Deref for AttachGuard<'a> {
+    type Target = JNIEnv<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.env
+    }
+}
+
+impl<'a> Drop for AttachGuard<'a> {
+    fn drop(&mut self) {
+        match self.detach() {
+            Ok(()) => (),
+            Err(e) => debug!("error detaching current thread: {:#?}", e),
+        }
+    }
+}

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1614,11 +1614,10 @@ impl<'a> JNIEnv<'a> {
     pub fn get_java_vm(&self) -> Result<JavaVM> {
         let mut raw = ptr::null_mut();
         unsafe {
-            // TODO: Handle errors
-            let _ = jni_unchecked!(self.internal, GetJavaVM, &mut raw);
+            let res = jni_unchecked!(self.internal, GetJavaVM, &mut raw);
+            jni_error_code_to_result(res)?;
             JavaVM::from_raw(raw)
         }
-        // ...
     }
 }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -15,6 +15,7 @@ use sys::{self, jarray, jboolean, jbyte, jchar, jdouble, jfloat, jint, jlong, js
           jvalue, jbooleanArray, jbyteArray, jcharArray, jdoubleArray, jfloatArray, jintArray,
           jlongArray, jobjectArray, jshortArray};
 use std::os::raw::{c_char, c_void};
+use std::ptr;
 
 use strings::JNIString;
 use strings::JavaStr;
@@ -37,6 +38,8 @@ use descriptors::Desc;
 use signature::TypeSignature;
 use signature::JavaType;
 use signature::Primitive;
+
+use JavaVM;
 
 /// FFI-compatible JNIEnv struct. You can safely use this as the JNIEnv argument
 /// to exported methods that will be called by java. This is where most of the
@@ -1605,6 +1608,17 @@ impl<'a> JNIEnv<'a> {
     /// Returns underlying `sys::JNIEnv` interface.
     pub fn get_native_interface(&self) -> *mut sys::JNIEnv {
         self.internal
+    }
+
+    /// Returns the Java VM interface.
+    pub fn get_java_vm(&self) -> Result<JavaVM> {
+        let mut raw = ptr::null_mut();
+        unsafe {
+            // TODO: Handle errors
+            let _ = jni_unchecked!(self.internal, GetJavaVM, &mut raw);
+            JavaVM::from_raw(raw)
+        }
+        // ...
     }
 }
 

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -111,7 +111,7 @@ impl DetachedGlobalRef {
                 let _ = self.attach_impl(&env);
                 Ok(())
             }
-            Err(Error(ErrorKind::Detached, _)) => {
+            Err(Error(ErrorKind::ThreadDetached, _)) => {
                 let env = self.vm.attach_current_thread()?;
                 let _ = self.attach_impl(&env);
                 Ok(())

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -1,10 +1,10 @@
 use std::convert::From;
+use std::mem;
 
+use JNIEnv;
 use errors::*;
-
 use objects::JObject;
-
-use sys::{jobject, JNIEnv};
+use sys::{self, jobject};
 
 /// A global JVM reference. These are "pinned" by the garbage collector and are
 /// guaranteed to not get collected until released. Thus, this is allowed to
@@ -12,7 +12,7 @@ use sys::{jobject, JNIEnv};
 /// since it requires a pointer to the `JNIEnv` to do anything useful with it.
 pub struct GlobalRef {
     obj: JObject<'static>,
-    env: *mut JNIEnv,
+    env: *mut sys::JNIEnv,
 }
 
 impl<'a> From<&'a GlobalRef> for JObject<'a> {
@@ -24,7 +24,7 @@ impl<'a> From<&'a GlobalRef> for JObject<'a> {
 impl GlobalRef {
     /// Create a new global reference object. This assumes that
     /// `CreateGlobalRef` has already been called.
-    pub unsafe fn new(env: *mut JNIEnv, obj: jobject) -> Self {
+    pub unsafe fn new(env: *mut sys::JNIEnv, obj: jobject) -> Self {
         GlobalRef {
             obj: JObject::from(obj),
             env: env,
@@ -46,6 +46,13 @@ impl GlobalRef {
     pub fn as_obj<'a>(&'a self) -> JObject<'a> {
         self.obj
     }
+
+    /// Detach the global ref from the JNI environment to send it across thread boundaries.
+    pub fn detach(self) -> DetachedGlobalRef {
+        let res = DetachedGlobalRef { obj: self.obj };
+        mem::forget(self); // prevent dropping the reference.
+        res
+    }
 }
 
 impl Drop for GlobalRef {
@@ -55,5 +62,38 @@ impl Drop for GlobalRef {
             Ok(()) => {}
             Err(e) => debug!("error dropping global ref: {:#?}", e),
         }
+    }
+}
+
+/// A detached global JVM reference that can be sent across threads. To do
+/// anything useful with it, it must be `attach`ed first.
+///
+/// Warning: detached global ref will leak memory if dropped. Attach to a
+/// `JNIEnv` to prevent this.
+#[must_use]
+pub struct DetachedGlobalRef {
+    obj: JObject<'static>,
+}
+
+unsafe impl Send for DetachedGlobalRef {}
+
+impl DetachedGlobalRef {
+    /// Creates a new detached global reference. This assumes that `CreateGlobalRef`
+    /// has alrady been called.
+    pub unsafe fn new(obj: sys::jobject) -> Self {
+        DetachedGlobalRef { obj: JObject::from(obj) }
+    }
+
+    /// Attach this ref to a `JNIEnv` to produce `GlobalRef`.
+    pub fn attach(self, env: &JNIEnv) -> GlobalRef {
+        GlobalRef {
+            obj: self.obj,
+            env: env.get_native_interface(),
+        }
+    }
+
+    /// Unwrap to the internal JNI type.
+    pub fn into_inner(self) -> sys::jobject {
+        self.obj.into_inner()
     }
 }


### PR DESCRIPTION
This PR adds initial support for the Invocation API (https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/invocation.html) with focus on enabling support for multi-threaded applications.

Changes:
- add `JavaVM` type to wrap (currently) a subset of the invocation API.
- add `get_java_vm` method to `JNIEnv` which returns the `JavaVM` interface.
- add `DetachedGlobalRef` and corresponding `GlobalRef::detach` to allow sending global refs across threads.
- extend the example to show how to write multi-threaded functions.

Limitations:
- Only `AttachCurrentThread`, `AttachCurrentThreadAsDaemon` and `DetachCurrentThread` are implemented of the Invocation API
- The `JavaVMAttachArgs` (last argument of `AttachCurrentThread` and `AttachCurrentThreadAsDaemon`) is not supported yet
- Only threads attached via `AttachCurrentThread` can be detached currently (this is implemented implicitly via RAII pattern. There is no explicit `detach_current_thread` method).
- `DetachedGlobalRef` leaks the global reference if dropped (must be converted to `GlobalRef` via `attach` to prevent this).
- Error handling could be improved (possibly involves adding new `Error` variants).
- Documentation could be more detailed.
