### PR TITLE
Run integration tests on multiple JVMs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,16 @@ matrix:
   allow_failures:
     - rust: nightly
 
-jdk:
-  - oraclejdk8
-
-env:
-  global:
-    - JAVA_HOME=/usr/lib/jvm/java-8-oracle
-    - LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server
-
 before_script:
   - export RUST_BACKTRACE=1
-  - echo $JAVA_HOME
-  - echo $LD_LIBRARY_PATH
 
 script:
   - cargo build
-  - cargo test --features=backtrace,invocation
+
+  - # Run all tests with Java 8 (the current LTS release).
+  - jdk_switcher use oraclejdk8
+  - ./run_integration_tests.sh
+
+  - # Run all tests with Java 9 (the latest release).
+  - jdk_switcher use oraclejdk9
+  - ./run_integration_tests.sh

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fail immediately in case of errors and/or unset variables
+set -eu -o pipefail
+
+echo "JAVA_HOME=${JAVA_HOME}"
+
+# Find the directory containing libjvm (the relative path has changed in Java 9)
+export LD_LIBRARY_PATH="$(find ${JAVA_HOME} -name libjvm.* -printf '%h\n')"
+echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+
+# Clean this package to make sure we always build with a currently set JDK version.
+cargo clean -p jni
+
+# Run the integration tests
+cargo test --features=backtrace,invocation


### PR DESCRIPTION
- Add a script that sets up proper environment variables and launches
integration tests.
- Run tests with JDK 8 & JDK 9 on the CI service.