### PR TITLE
A test to ensure `DeleteGlobalRef` is called.

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -287,7 +287,7 @@ impl<'a> JNIEnv<'a> {
     pub fn new_global_ref(&self, obj: JObject) -> Result<GlobalRef> {
         non_null!(obj, "new_global_ref obj argument");
         let new_ref: JObject = jni_call!(self.internal, NewGlobalRef, obj.into_inner());
-        let global = unsafe { GlobalRef::new(self.get_java_vm()?, new_ref.into_inner()) };
+        let global = unsafe { GlobalRef::from_raw(self.get_java_vm()?, new_ref.into_inner()) };
         Ok(global)
     }
 

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -3,36 +3,16 @@ extern crate error_chain;
 extern crate jni;
 
 use error_chain::ChainedError;
-use jni::{InitArgsBuilder, JNIEnv, JNIVersion, JavaVM};
 use jni::objects::JObject;
 use jni::objects::JValue;
 
-fn print_exception(env: &JNIEnv) {
-    let exception_occurred = env.exception_check()
-        .unwrap_or_else(|e| panic!(format!("{:?}", e)));
-    if exception_occurred {
-        env.exception_describe()
-            .unwrap_or_else(|e| panic!(format!("{:?}", e)));
-    }
-}
+mod util;
+use util::{jvm, print_exception};
+
 
 #[test]
 fn test_java_integers() {
-    let jvm_args = InitArgsBuilder::new()
-        .version(JNIVersion::V8)
-        .option("-Xcheck:jni")
-        .option("-Xdebug")
-        .build()
-        .unwrap_or_else(|e| {
-            panic!(format!("{}", e.display_chain().to_string()));
-        });
-
-    let jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| {
-        panic!(format!("{}", e.display_chain().to_string()));
-    });
-
-
-    let env = jvm.attach_current_thread()
+    let env = jvm().attach_current_thread()
         .expect("failed to attach jvm thread");
 
     let array_length = 50;
@@ -63,8 +43,8 @@ fn test_java_integers() {
 
             Ok(JObject::null())
         }).unwrap_or_else(|e| {
-                print_exception(&env);
-                panic!(format!("{}", e.display_chain().to_string()));
-            });
+            print_exception(&env);
+            panic!(format!("{}", e.display_chain().to_string()));
+        });
     }
 }

--- a/tests/jni_global_ref_is_deleted.rs
+++ b/tests/jni_global_ref_is_deleted.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "invocation")]
+extern crate error_chain;
+extern crate jni;
+
+use jni::objects::AutoLocal;
+use jni::objects::GlobalRef;
+use jni::objects::JValue;
+use jni::sys::jint;
+
+mod util;
+use util::*;
+
+
+const VALUE: jint = 42;
+
+
+/// The specification does not provide what should happen when a deleted reference is accessed.
+/// [https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#Call_type_Method_routines]
+///
+/// So, we just test, that an error occurs.
+///
+/// But worse, the reference can again become a "valid" that makes this test fragile
+/// [https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetObjectRefType]
+///
+/// "Since references are typically implemented as pointers to memory data structures that can
+/// potentially be reused by any of the reference allocation services in the VM, once deleted,
+/// it is not specified what value the GetObjectRefType will return".
+///
+/// *To avoid race condition this test routine should remain in a separate binary file.*
+
+#[test]
+pub fn global_ref_is_dropped() {
+    let env = jvm().attach_current_thread().unwrap();
+
+    let global_obj = {
+        let local_ref = AutoLocal::new(&env, unwrap(&env, env.new_object(
+            "java/util/concurrent/atomic/AtomicInteger",
+            "(I)V",
+            &[JValue::from(VALUE)]
+        )));
+        let global_ref = unwrap(&env, env.new_global_ref(local_ref.as_obj()));
+
+        let res = env.call_method(global_ref.as_obj(), "get", "()I", &[]);
+        assert_eq!(VALUE, unwrap(&env, unwrap(&env, res).i()));
+
+        let obj = global_ref.as_obj().into_inner();
+
+        // check that the other object still works
+        let global_ref = unsafe { GlobalRef::from_raw(env.get_java_vm().unwrap(), obj) };
+        let res = env.call_method(global_ref.as_obj(), "get", "()I", &[]);
+        assert_eq!(VALUE, unwrap(&env, unwrap(&env, res).i()));
+        std::mem::forget(global_ref);
+
+        obj
+    }; // << - here global and local references should already be deleted
+
+    let global_ref = unsafe { GlobalRef::from_raw(env.get_java_vm().unwrap(), global_obj) };
+    let res = env.call_method(global_ref.as_obj(), "get", "()I", &[]);
+
+    assert!(res.is_err());
+}

--- a/tests/jni_global_ref_is_deleted.rs
+++ b/tests/jni_global_ref_is_deleted.rs
@@ -8,10 +8,7 @@ use jni::objects::JValue;
 use jni::sys::jint;
 
 mod util;
-use util::*;
-
-
-const VALUE: jint = 42;
+use util::{jvm, unwrap};
 
 
 /// The specification does not provide what should happen when a deleted reference is accessed.
@@ -30,7 +27,10 @@ const VALUE: jint = 42;
 
 #[test]
 pub fn global_ref_is_dropped() {
-    let env = jvm().attach_current_thread().unwrap();
+    const VALUE: jint = 42;
+
+    let env = jvm().attach_current_thread()
+        .expect("failed to attach jvm thread");;
 
     let global_obj = {
         let local_ref = AutoLocal::new(&env, unwrap(&env, env.new_object(

--- a/tests/jni_global_refs.rs
+++ b/tests/jni_global_refs.rs
@@ -2,59 +2,16 @@
 extern crate error_chain;
 extern crate jni;
 
-use std::sync::{Arc, Barrier, Once, ONCE_INIT};
+use std::sync::{Arc, Barrier};
 use std::thread::spawn;
 
-use error_chain::ChainedError;
-use jni::{InitArgsBuilder, JNIEnv, JNIVersion, JavaVM};
-use jni::errors::Result;
 use jni::objects::AutoLocal;
 use jni::objects::JValue;
 use jni::sys::jint;
 
+mod util;
+use util::*;
 
-pub fn jvm() -> &'static Arc<JavaVM> {
-    static mut JVM: Option<Arc<JavaVM>> = None;
-    static INIT: Once = ONCE_INIT;
-
-
-    INIT.call_once(|| {
-        let jvm_args = InitArgsBuilder::new()
-            .version(JNIVersion::V8)
-            .option("-Xcheck:jni")
-            .option("-Xdebug")
-            .build()
-            .unwrap_or_else(|e| {
-                panic!(format!("{}", e.display_chain().to_string()));
-            });
-
-        let jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| {
-            panic!(format!("{}", e.display_chain().to_string()));
-        });
-
-        unsafe {
-            JVM = Some(Arc::new(jvm));
-        }
-    });
-
-    unsafe { JVM.as_ref().unwrap() }
-}
-
-fn print_exception(env: &JNIEnv) {
-    let exception_occurred = env.exception_check()
-        .unwrap_or_else(|e| panic!(format!("{:?}", e)));
-    if exception_occurred {
-        env.exception_describe()
-            .unwrap_or_else(|e| panic!(format!("{:?}", e)));
-    }
-}
-
-fn unwrap<T>(env: &JNIEnv, res: Result<T>) -> T {
-    res.unwrap_or_else(|e| {
-        print_exception(&env);
-        panic!(format!("{}", e.display_chain().to_string()));
-    })
-}
 
 #[test]
 pub fn global_ref_works_in_other_threads() {

--- a/tests/jni_global_refs.rs
+++ b/tests/jni_global_refs.rs
@@ -10,14 +10,15 @@ use jni::objects::JValue;
 use jni::sys::jint;
 
 mod util;
-use util::*;
+use util::{jvm, unwrap};
 
 
 #[test]
 pub fn global_ref_works_in_other_threads() {
     const ITERS_PER_THREAD: usize = 10_000;
 
-    let env = jvm().attach_current_thread().unwrap();
+    let env = jvm().attach_current_thread()
+        .expect("failed to attach jvm thread");
     let mut join_handlers = Vec::new();
 
     let atomic_integer = {

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,0 +1,50 @@
+use std::sync::{Arc, Once, ONCE_INIT};
+
+use error_chain::ChainedError;
+use jni::{InitArgsBuilder, JNIEnv, JNIVersion, JavaVM};
+use jni::errors::Result;
+
+
+pub fn jvm() -> &'static Arc<JavaVM> {
+    static mut JVM: Option<Arc<JavaVM>> = None;
+    static INIT: Once = ONCE_INIT;
+
+
+    INIT.call_once(|| {
+        let jvm_args = InitArgsBuilder::new()
+            .version(JNIVersion::V8)
+            .option("-Xcheck:jni")
+            .option("-Xdebug")
+            .build()
+            .unwrap_or_else(|e| {
+                panic!(format!("{}", e.display_chain().to_string()));
+            });
+
+        let jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| {
+            panic!(format!("{}", e.display_chain().to_string()));
+        });
+
+        unsafe {
+            JVM = Some(Arc::new(jvm));
+        }
+    });
+
+    unsafe { JVM.as_ref().unwrap() }
+}
+
+pub fn print_exception(env: &JNIEnv) {
+    let exception_occurred = env.exception_check()
+        .unwrap_or_else(|e| panic!(format!("{:?}", e)));
+    if exception_occurred {
+        env.exception_describe()
+            .unwrap_or_else(|e| panic!(format!("{:?}", e)));
+    }
+}
+
+pub fn unwrap<T>(env: &JNIEnv, res: Result<T>) -> T {
+    res.unwrap_or_else(|e| {
+        print_exception(&env);
+        panic!(format!("{}", e.display_chain().to_string()));
+    })
+}
+

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -9,7 +9,6 @@ pub fn jvm() -> &'static Arc<JavaVM> {
     static mut JVM: Option<Arc<JavaVM>> = None;
     static INIT: Once = ONCE_INIT;
 
-
     INIT.call_once(|| {
         let jvm_args = InitArgsBuilder::new()
             .version(JNIVersion::V8)
@@ -41,6 +40,7 @@ pub fn print_exception(env: &JNIEnv) {
     }
 }
 
+#[allow(dead_code)]
 pub fn unwrap<T>(env: &JNIEnv, res: Result<T>) -> T {
     res.unwrap_or_else(|e| {
         print_exception(&env);


### PR DESCRIPTION
As suggested in a comment https://github.com/prevoty/jni-rs/pull/67#pullrequestreview-87438603 this test checks that `DeleteGlobalRef` was called.

Additionally, few auxilliary functions are placed in a separate module. Perhaps some of these functions should be available in the public API for tests in dependent projects.

I renamed `GlobalRef::new` into `from_raw`, it seems more consistent with `JavaVM`, `JNIEnv`, and common patterns of Rust libs; and I made it public to be usable in tests, but this is not so necessary, we can make a helper method/function available only for tests, so `from_raw` can be a private method. But I think `new` renamed to `from_raw` is less confusing for users and while still `unsafe` it does not look like intended for widespread use.

CC @jechase , @dmitry-timofeev , @DarkEld3r , @fpoli 